### PR TITLE
Fix quick typo.

### DIFF
--- a/src/default_options.hpp
+++ b/src/default_options.hpp
@@ -31,7 +31,7 @@ nlohmann::json default_options =
       {"cfl", 1.0} // target CFL number
    }},
 
-   {"lin_solver",
+   {"lin-solver",
    {
       {"print-lvl", 0}, // linear solver print level (no printing if zero)
       {"max-iter", 100}, // default to 100 iterations


### PR DESCRIPTION
Change `lin_solver` heading to `lin-solver` to stay consistent with other option headings.