### PR TITLE
Addressing Issue #13

### DIFF
--- a/src/solver.hpp
+++ b/src/solver.hpp
@@ -185,7 +185,7 @@ protected:
    virtual void addInterfaceIntegrators(double alpha) {};
 
    /// Define the number of states, the finite element space, and state u
-   virtual int getNumState() {};
+   virtual int getNumState() = 0; 
 
    /// Create `output` based on `options` and add approporiate integrators
    virtual void addOutputs() {};


### PR DESCRIPTION
@jehicken opening a PR to address #13.

If not making the `add*Integrators` functions pure virtual, what are your thoughts on having them throw an error by default? My goal with that is to force whoever implements a new solver to explicitly consider which integrators they need to implement; where the current implementation could allow someone to forget to include an implementation. I'm back to thinking pure virtual is better though, as it would create a compile-time error vs a runtime error and be caught sooner.