### PR TITLE
Fix issue introduced by MFEM update

### DIFF
--- a/src/common/evolver.cpp
+++ b/src/common/evolver.cpp
@@ -175,7 +175,7 @@ MachEvolver::MachEvolver(
          mass.Reset(_mass, false);
          mass_prec.reset(new OperatorJacobiSmoother(*_mass, ess_tdof_list));
       }
-      else if (mass_assem == AssemblyLevel::FULL)
+      else if (mass_assem == AssemblyLevel::LEGACYFULL)
       {
          mass.Reset(_mass->ParallelAssemble(), true);
          mass_prec.reset(new HypreSmoother(*mass.As<HypreParMatrix>(),


### PR DESCRIPTION
This fixes an issue where the tests had failed as a result of the original PR from this branch. MFEM changed the meaning of`AssemblyLevel::FULL` to `AssemblyLevel::LEGACYFULL`. This updates our code to account for the change.