### PR TITLE
Updating mach to support the latest version of mfem on the odl branch.

### DIFF
--- a/src/physics/res_integ.cpp
+++ b/src/physics/res_integ.cpp
@@ -7,8 +7,9 @@ namespace mach
 {
 
 void DomainResIntegrator::AssembleElementVector(const FiniteElement &elx,
-                                       ElementTransformation &Trx,
-                                       const Vector &elfunx, Vector &elvect)
+                                                ElementTransformation &Trx,
+                                                const Vector &elfunx,
+                                                Vector &elvect)
 {   
     /// get the proper element, transformation, and state vector
     Array<int> vdofs; Vector elfun; Vector eladj;
@@ -67,8 +68,9 @@ void DomainResIntegrator::AssembleElementVector(const FiniteElement &elx,
 }
 
 void MassResIntegrator::AssembleElementVector(const FiniteElement &elx,
-                                       ElementTransformation &Trx,
-                                       const Vector &elfunx, Vector &elvect)
+                                              ElementTransformation &Trx,
+                                              const Vector &elfunx,
+                                              Vector &elvect)
 {
     /// get the proper element, transformation, and state vector
     Array<int> vdofs; Vector elfun; Vector eladj; 
@@ -131,8 +133,9 @@ void MassResIntegrator::AssembleElementVector(const FiniteElement &elx,
 }
 
 void DiffusionResIntegrator::AssembleElementVector(const FiniteElement &elx,
-                                       ElementTransformation &Trx,
-                                       const Vector &elfunx, Vector &elvect)
+                                                   ElementTransformation &Trx,
+                                                   const Vector &elfunx,
+                                                   Vector &elvect)
 {
     /// get the proper element, transformation, and state vector
     Array<int> vdofs; Vector elfun; Vector eladj; 
@@ -214,10 +217,12 @@ void DiffusionResIntegrator::AssembleElementVector(const FiniteElement &elx,
     }
 }
 
-void BoundaryNormalResIntegrator::AssembleFaceVector(const FiniteElement &el1x,
-                                        const FiniteElement &el2x,
-                                         FaceElementTransformations &Trx,
-                                         const Vector &elfunx, Vector &elvect)
+void BoundaryNormalResIntegrator::AssembleFaceVector(
+   const FiniteElement &el1x,
+   const FiniteElement &el2x,
+   FaceElementTransformations &Trx,
+   const Vector &elfunx,
+   Vector &elvect)
 {   
     /// get the proper element, transformation, and state vector
     Array<int> vdofs; Vector elfun; Vector eladj;
@@ -286,8 +291,8 @@ void BoundaryNormalResIntegrator::AssembleFaceVector(const FiniteElement &el1x,
 
 #if 0
 double DomainResIntegrator::GetElementEnergy(const FiniteElement &elx,
-                                       ElementTransformation &Trx,
-                                       const Vector &elfunx)
+                                             ElementTransformation &Trx,
+                                             const Vector &elfunx)
 {
     double Rpart = 0;
     
@@ -330,8 +335,8 @@ double DomainResIntegrator::GetElementEnergy(const FiniteElement &elx,
 }
 
 double MassResIntegrator::GetElementEnergy(const FiniteElement &elx,
-                                       ElementTransformation &Trx,
-                                       const Vector &elfunx)
+                                           ElementTransformation &Trx,
+                                           const Vector &elfunx)
 {
     double Rpart = 0;
     

--- a/src/physics/thermal/temp_integ.cpp
+++ b/src/physics/thermal/temp_integ.cpp
@@ -7,17 +7,16 @@ using namespace std;
 namespace mach
 {
 
-AggregateIntegrator::AggregateIntegrator(
-                              const mfem::FiniteElementSpace *fe_space,
-                              const double r,
-                              const mfem::Vector m,
-                              mfem::GridFunction *temp)       
+AggregateIntegrator::AggregateIntegrator(const FiniteElementSpace *fe_space,
+                                         const double r,
+                                         const Vector m,
+                                         GridFunction *temp)       
    : fes(fe_space), rho(r), max(m)
 { 
    GetIEAggregate(temp);
 }
 
-double AggregateIntegrator::GetIEAggregate(mfem::GridFunction *temp)
+double AggregateIntegrator::GetIEAggregate(GridFunction *temp)
 {
    cout.flush();
    Array<int> dofs;
@@ -61,9 +60,9 @@ double AggregateIntegrator::GetIEAggregate(mfem::GridFunction *temp)
    return J_;
 }
 
-double AggregateIntegrator::GetElementEnergy(const mfem::FiniteElement &el, 
-               mfem::ElementTransformation &Trans,
-               const mfem::Vector &elfun)
+double AggregateIntegrator::GetElementEnergy(const FiniteElement &el, 
+                                             ElementTransformation &Trans,
+                                             const Vector &elfun)
 {
    double Jpart = 0;
    // const int dof = el.GetDof();
@@ -85,9 +84,10 @@ double AggregateIntegrator::GetElementEnergy(const mfem::FiniteElement &el,
    return Jpart/denom_;
 }
 
-void AggregateIntegrator::AssembleElementVector(const mfem::FiniteElement &el, 
-               mfem::ElementTransformation &Trans,
-               const mfem::Vector &elfun, mfem::Vector &elvect)
+void AggregateIntegrator::AssembleElementVector(const FiniteElement &el, 
+                                                ElementTransformation &Trans,
+                                                const Vector &elfun,
+                                                Vector &elvect)
 {
    int dof = el.GetDof(); //, dim = el.GetDim();
    elvect.SetSize(dof);
@@ -114,14 +114,14 @@ void AggregateIntegrator::AssembleElementVector(const mfem::FiniteElement &el,
 }
 
 
-TempIntegrator::TempIntegrator( const mfem::FiniteElementSpace *fe_space,
-                              mfem::GridFunction *temp)       
+TempIntegrator::TempIntegrator(const FiniteElementSpace *fe_space,
+                               GridFunction *temp)       
    : fes(fe_space), temp_(temp)
 { 
    //GetTemp(temp);
 }
 
-double TempIntegrator::GetTemp(mfem::GridFunction *temp)
+double TempIntegrator::GetTemp(GridFunction *temp)
 {
    cout.flush();
    Array<int> dofs;
@@ -162,9 +162,10 @@ double TempIntegrator::GetTemp(mfem::GridFunction *temp)
    return J_;
 }
 
-void TempIntegrator::AssembleElementVector(const mfem::FiniteElement &el, 
-               mfem::ElementTransformation &Trans,
-               const mfem::Vector &elfun, mfem::Vector &elvect)
+void TempIntegrator::AssembleElementVector(const FiniteElement &el, 
+                                           ElementTransformation &Trans,
+                                           const Vector &elfun,
+                                           Vector &elvect)
 {
    int dof = el.GetDof(); //, dim = el.GetDim();
    elvect.SetSize(dof);
@@ -183,10 +184,11 @@ void TempIntegrator::AssembleElementVector(const mfem::FiniteElement &el,
    }
 }
 
-void TempIntegrator::AssembleFaceVector(const mfem::FiniteElement &el1, 
-               const mfem::FiniteElement &el2, 
-               mfem::FaceElementTransformations &Trans,
-               const mfem::Vector &elfun, mfem::Vector &elvect)
+void TempIntegrator::AssembleFaceVector(const FiniteElement &el1, 
+                                        const FiniteElement &el2, 
+                                        FaceElementTransformations &Trans,
+                                        const Vector &elfun,
+                                        Vector &elvect)
 {
    int dof = el1.GetDof(); //, dim = el1.GetDim();
    elvect.SetSize(dof);
@@ -210,16 +212,16 @@ void TempIntegrator::AssembleFaceVector(const mfem::FiniteElement &el1,
 
 
 AggregateResIntegrator::AggregateResIntegrator(
-                              const mfem::FiniteElementSpace *fe_space,
-                              const double r,
-                              const mfem::Vector m,
-                              mfem::GridFunction *temp)       
+   const FiniteElementSpace *fe_space,
+   const double r,
+   const Vector m,
+   GridFunction *temp)       
    : fes(fe_space), rho(r), max(m)
 { 
    GetIEAggregate(temp);
 }
 
-double AggregateResIntegrator::GetIEAggregate(mfem::GridFunction *temp)
+double AggregateResIntegrator::GetIEAggregate(GridFunction *temp)
 {
    cout.flush();
    Array<int> dofs;
@@ -264,9 +266,10 @@ double AggregateResIntegrator::GetIEAggregate(mfem::GridFunction *temp)
    return J_;
 }
 
-void AggregateResIntegrator::AssembleElementVector(const mfem::FiniteElement &elx, 
-               mfem::ElementTransformation &Trx,
-               const mfem::Vector &elfunx, mfem::Vector &elvect)
+void AggregateResIntegrator::AssembleElementVector(const FiniteElement &elx, 
+                                                   ElementTransformation &Trx,
+                                                   const Vector &elfunx,
+                                                   Vector &elvect)
 {
    /// get the proper element, transformation, and state vector
    Array<int> vdofs; Vector elfun; 

--- a/src/physics/thermal/temp_integ.hpp
+++ b/src/physics/thermal/temp_integ.hpp
@@ -74,21 +74,24 @@ public:
 
    /// Overloaded, precomputes for use in adjoint
    TempIntegrator(const mfem::FiniteElementSpace *fe_space,
-                              mfem::GridFunction *temp);
+                  mfem::GridFunction *temp);
 
+   /// TODO: Turn this into a GetElementEnergy and GetFaceEnergy
    /// Computes the induced functional estimate for aggregated temperature
 	double GetTemp(mfem::GridFunction *temp);
 
    /// Computes dJdu, for the adjoint
-   virtual void AssembleElementVector(const mfem::FiniteElement &el, 
-               mfem::ElementTransformation &Trans,
-               const mfem::Vector &elfun, mfem::Vector &elvect);
+   void AssembleElementVector(const mfem::FiniteElement &el, 
+                              mfem::ElementTransformation &Trans,
+                              const mfem::Vector &elfun,
+                              mfem::Vector &elvect) override;
 
    /// Computes dJdu for the adjoint on the boundary
-   virtual void AssembleFaceVector(const mfem::FiniteElement &el1, 
-               const mfem::FiniteElement &el2, 
-               mfem::FaceElementTransformations  &Trans,
-               const mfem::Vector &elfun, mfem::Vector &elvect);
+   void AssembleFaceVector(const mfem::FiniteElement &el1, 
+                           const mfem::FiniteElement &el2, 
+                           mfem::FaceElementTransformations  &Trans,
+                           const mfem::Vector &elfun,
+                           mfem::Vector &elvect) override;
 private: 
 
    /// used to integrate over appropriate elements

--- a/test/unit/euler_test_data.cpp
+++ b/test/unit/euler_test_data.cpp
@@ -1,6 +1,8 @@
 #include "euler_test_data.hpp"
 #include "euler_fluxes.hpp"
 
+using namespace mfem;
+
 namespace euler_data
 {
 
@@ -73,7 +75,7 @@ static std::default_random_engine gen(std::random_device{}());
 static std::uniform_real_distribution<double> uniform_rand(0.0, 1.0);
 
 template <int dim, bool entvar>
-void randBaselinePert(const mfem::Vector &x, mfem::Vector &u)
+void randBaselineVectorPert(const Vector &x, Vector &u)
 {
     const double scale = 0.01;
     u(0) = rho * (1.0 + scale * uniform_rand(gen));
@@ -84,19 +86,19 @@ void randBaselinePert(const mfem::Vector &x, mfem::Vector &u)
     }
     if (entvar)
     {
-       mfem::Vector q(u);
+       Vector q(u);
        mach::calcEntropyVars<double, dim>(q.GetData(), u.GetData());
     }
 }
 // explicit instantiation of the templated function above
-template void randBaselinePert<1, true>(const mfem::Vector &x, mfem::Vector &u);
-template void randBaselinePert<2, true>(const mfem::Vector &x, mfem::Vector &u);
-template void randBaselinePert<3, true>(const mfem::Vector &x, mfem::Vector &u);
-template void randBaselinePert<1, false>(const mfem::Vector &x, mfem::Vector &u);
-template void randBaselinePert<2, false>(const mfem::Vector &x, mfem::Vector &u);
-template void randBaselinePert<3, false>(const mfem::Vector &x, mfem::Vector &u);
+template void randBaselineVectorPert<1, true>(const Vector &x, Vector &u);
+template void randBaselineVectorPert<2, true>(const Vector &x, Vector &u);
+template void randBaselineVectorPert<3, true>(const Vector &x, Vector &u);
+template void randBaselineVectorPert<1, false>(const Vector &x, Vector &u);
+template void randBaselineVectorPert<2, false>(const Vector &x, Vector &u);
+template void randBaselineVectorPert<3, false>(const Vector &x, Vector &u);
 
-void randState(const mfem::Vector &x, mfem::Vector &u)
+void randVectorState(const Vector &x, Vector &u)
 {
     for (int i = 0; i < u.Size(); ++i)
     {
@@ -104,13 +106,13 @@ void randState(const mfem::Vector &x, mfem::Vector &u)
     }
 }
 
-double randBaselinePert(const mfem::Vector &x)
+double randBaselinePert(const Vector &x)
 {
     const double scale = 0.01;
     return 1.0 + scale * uniform_rand(gen);
 }
 
-double randState(const mfem::Vector &x)
+double randState(const Vector &x)
 {
     return 2.0 * uniform_rand(gen) - 1.0;
 }

--- a/test/unit/euler_test_data.hpp
+++ b/test/unit/euler_test_data.hpp
@@ -69,12 +69,12 @@ extern double delw_data[15];
 /// \tparam dim - number of spatial dimensions (1, 2, or 3)
 /// \tparam entvar - if true, returns entropy variables
 template <int dim, bool entvar = false>
-void randBaselinePert(const mfem::Vector &x, mfem::Vector &u);
+void randBaselineVectorPert(const mfem::Vector &x, mfem::Vector &u);
 
 /// Returns a random state with entries uniformly distributed in [-1,1]
 /// \param[in] x - coordinates (not used)
 /// \param[out] u - rand state variable
-void randState(const mfem::Vector &x, mfem::Vector &u);
+void randVectorState(const mfem::Vector &x, mfem::Vector &u);
 
 /// Returns a perturbed version of the baseline temperature state
 /// \param[in] x - coordinates (not used)

--- a/test/unit/test_euler_assemble.cpp
+++ b/test/unit/test_euler_assemble.cpp
@@ -34,12 +34,12 @@ TEST_CASE("EulerIntegrator::AssembleElementGrad", "[EulerIntegrator]")
 
          // initialize state; here we randomly perturb a constant state
          GridFunction q(fes.get());
-         VectorFunctionCoefficient pert(num_state, randBaselinePert<2>);
+         VectorFunctionCoefficient pert(num_state, randBaselineVectorPert<2>);
          q.ProjectCoefficient(pert);
 
          // initialize the vector that the Jacobian multiplies
          GridFunction v(fes.get());
-         VectorFunctionCoefficient v_rand(num_state, randState);
+         VectorFunctionCoefficient v_rand(num_state, randVectorState);
          v.ProjectCoefficient(v_rand);
 
          // evaluate the Jacobian and compute its product with v
@@ -74,12 +74,12 @@ TEST_CASE("EulerIntegrator::AssembleElementGrad", "[EulerIntegrator]")
 
          // initialize state; here we randomly perturb a constant state
          GridFunction q(fes.get());
-         VectorFunctionCoefficient pert(num_state, randBaselinePert<2>);
+         VectorFunctionCoefficient pert(num_state, randBaselineVectorPert<2>);
          q.ProjectCoefficient(pert);
 
          // initialize the vector that the Jacobian multiplies
          GridFunction v(fes.get());
-         VectorFunctionCoefficient v_rand(num_state, randState);
+         VectorFunctionCoefficient v_rand(num_state, randVectorState);
          v.ProjectCoefficient(v_rand);
 
          // evaluate the Jacobian and compute its product with v
@@ -133,12 +133,12 @@ TEST_CASE("SlipWallBC::AssembleFaceGrad", "[SlipWallBC]")
 
          // initialize state; here we randomly perturb a constant state
          GridFunction q(fes.get());
-         VectorFunctionCoefficient pert(num_state, randBaselinePert<dim>);
+         VectorFunctionCoefficient pert(num_state, randBaselineVectorPert<dim>);
          q.ProjectCoefficient(pert);
 
          // initialize the vector that the Jacobian multiplies
          GridFunction v(fes.get());
-         VectorFunctionCoefficient v_rand(num_state, randState);
+         VectorFunctionCoefficient v_rand(num_state, randVectorState);
          v.ProjectCoefficient(v_rand);
 
          // evaluate the Jacobian and compute its product with v
@@ -174,12 +174,12 @@ TEST_CASE("SlipWallBC::AssembleFaceGrad", "[SlipWallBC]")
 
          // initialize state; here we randomly perturb a constant state
          GridFunction q(fes.get());
-         VectorFunctionCoefficient pert(num_state, randBaselinePert<dim>);
+         VectorFunctionCoefficient pert(num_state, randBaselineVectorPert<dim>);
          q.ProjectCoefficient(pert);
 
          // initialize the vector that the Jacobian multiplies
          GridFunction v(fes.get());
-         VectorFunctionCoefficient v_rand(num_state, randState);
+         VectorFunctionCoefficient v_rand(num_state, randVectorState);
          v.ProjectCoefficient(v_rand);
 
          // evaluate the Jacobian and compute its product with v
@@ -238,12 +238,12 @@ TEST_CASE("PressureForce::AssembleVector", "[PressureForce]")
 
          // initialize state; here we randomly perturb a constant state
          GridFunction q(fes.get());
-         VectorFunctionCoefficient pert(num_state, randBaselinePert<dim>);
+         VectorFunctionCoefficient pert(num_state, randBaselineVectorPert<dim>);
          q.ProjectCoefficient(pert);
 
          // initialize the vector that dJdu multiplies
          GridFunction v(fes.get());
-         VectorFunctionCoefficient v_rand(num_state, randState);
+         VectorFunctionCoefficient v_rand(num_state, randVectorState);
          v.ProjectCoefficient(v_rand);
 
          // evaluate dJdu and compute its product with v
@@ -274,12 +274,12 @@ TEST_CASE("PressureForce::AssembleVector", "[PressureForce]")
 
          // initialize state; here we randomly perturb a constant state
          GridFunction q(fes.get());
-         VectorFunctionCoefficient pert(num_state, randBaselinePert<dim>);
+         VectorFunctionCoefficient pert(num_state, randBaselineVectorPert<dim>);
          q.ProjectCoefficient(pert);
 
          // initialize the vector that dJdu multiplies
          GridFunction v(fes.get());
-         VectorFunctionCoefficient v_rand(num_state, randState);
+         VectorFunctionCoefficient v_rand(num_state, randVectorState);
          v.ProjectCoefficient(v_rand);
 
          // evaluate dJdu and compute its product with v
@@ -330,12 +330,12 @@ TEMPLATE_TEST_CASE_SIG("DyadicFluxIntegrator::AssembleElementGrad",
 
          // initialize state; here we randomly perturb a constant state
          GridFunction q(fes.get());
-         VectorFunctionCoefficient pert(num_state, randBaselinePert<2,entvar>);
+         VectorFunctionCoefficient pert(num_state, randBaselineVectorPert<2,entvar>);
          q.ProjectCoefficient(pert);
 
          // initialize the vector that the Jacobian multiplies
          GridFunction v(fes.get());
-         VectorFunctionCoefficient v_rand(num_state, randState);
+         VectorFunctionCoefficient v_rand(num_state, randVectorState);
          v.ProjectCoefficient(v_rand);
 
          // evaluate the Jacobian and compute its product with v
@@ -370,12 +370,12 @@ TEMPLATE_TEST_CASE_SIG("DyadicFluxIntegrator::AssembleElementGrad",
 
          // initialize state; here we randomly perturb a constant state
          GridFunction q(fes.get());
-         VectorFunctionCoefficient pert(num_state, randBaselinePert<2, entvar>);
+         VectorFunctionCoefficient pert(num_state, randBaselineVectorPert<2, entvar>);
          q.ProjectCoefficient(pert);
 
          // initialize the vector that the Jacobian multiplies
          GridFunction v(fes.get());
-         VectorFunctionCoefficient v_rand(num_state, randState);
+         VectorFunctionCoefficient v_rand(num_state, randVectorState);
          v.ProjectCoefficient(v_rand);
 
          // evaluate the Jacobian and compute its product with v
@@ -433,12 +433,12 @@ TEMPLATE_TEST_CASE_SIG("DyadicFluxIntegrator::AssembleElementGrad",
 
 //          // initialize state; here we randomly perturb a constant state
 //          GridFunction q(fes.get());
-//          VectorFunctionCoefficient pert(num_state, randBaselinePert<dim>);
+//          VectorFunctionCoefficient pert(num_state, randBaselineVectorPert<dim>);
 //          q.ProjectCoefficient(pert);
 
 //          // initialize the vector that the Jacobian multiplies
 //          GridFunction v(fes.get());
-//          VectorFunctionCoefficient v_rand(num_state, randState);
+//          VectorFunctionCoefficient v_rand(num_state, randVectorState);
 //          v.ProjectCoefficient(v_rand);
 
 //          // evaluate the Jacobian and compute its product with v
@@ -494,12 +494,12 @@ TEMPLATE_TEST_CASE_SIG("EntStableLPSIntegrator::AssembleElementGrad using entvar
 
          // initialize state; here we randomly perturb a constant state
          GridFunction q(fes.get());
-         VectorFunctionCoefficient pert(num_state, randBaselinePert<2, entvar>);
+         VectorFunctionCoefficient pert(num_state, randBaselineVectorPert<2, entvar>);
          q.ProjectCoefficient(pert);
 
          // initialize the vector that the Jacobian multiplies
          GridFunction v(fes.get());
-         VectorFunctionCoefficient v_rand(num_state, randState);
+         VectorFunctionCoefficient v_rand(num_state, randVectorState);
          v.ProjectCoefficient(v_rand);
 
          // evaluate the Jacobian and compute its product with v
@@ -534,12 +534,12 @@ TEMPLATE_TEST_CASE_SIG("EntStableLPSIntegrator::AssembleElementGrad using entvar
 
          // initialize state; here we randomly perturb a constant state
          GridFunction q(fes.get());
-         VectorFunctionCoefficient pert(num_state, randBaselinePert<2, entvar>);
+         VectorFunctionCoefficient pert(num_state, randBaselineVectorPert<2, entvar>);
          q.ProjectCoefficient(pert);
 
          // initialize the vector that the Jacobian multiplies
          GridFunction v(fes.get());
-         VectorFunctionCoefficient v_rand(num_state, randState);
+         VectorFunctionCoefficient v_rand(num_state, randVectorState);
          v.ProjectCoefficient(v_rand);
 
          // evaluate the Jacobian and compute its product with v
@@ -590,12 +590,12 @@ TEMPLATE_TEST_CASE_SIG("MassIntegrator::AssembleElementGrad",
 
          // initialize state; we randomly perturb a constant state
          GridFunction u(fes.get());
-         VectorFunctionCoefficient pert(num_state, randBaselinePert<2, entvar>);
+         VectorFunctionCoefficient pert(num_state, randBaselineVectorPert<2, entvar>);
          u.ProjectCoefficient(pert);
 
          // initialize the vector that the Jacobian multiplies
          GridFunction v(fes.get());
-         VectorFunctionCoefficient v_rand(num_state, randState);
+         VectorFunctionCoefficient v_rand(num_state, randVectorState);
          v.ProjectCoefficient(v_rand);
 
          NonlinearForm res(fes.get());
@@ -631,12 +631,12 @@ TEMPLATE_TEST_CASE_SIG("MassIntegrator::AssembleElementGrad",
 
          // initialize state and k = du/dt; here we randomly perturb a constant state
          GridFunction u(fes.get());
-         VectorFunctionCoefficient pert(num_state, randBaselinePert<2, entvar>);
+         VectorFunctionCoefficient pert(num_state, randBaselineVectorPert<2, entvar>);
          u.ProjectCoefficient(pert);
 
          // initialize the vector that the Jacobian multiplies
          GridFunction v(fes.get());
-         VectorFunctionCoefficient v_rand(num_state, randState);
+         VectorFunctionCoefficient v_rand(num_state, randVectorState);
          v.ProjectCoefficient(v_rand);
 
          NonlinearForm res(fes.get());
@@ -700,12 +700,12 @@ TEMPLATE_TEST_CASE_SIG("InviscidFaceIntegrator::AssembleFaceGrad",
 
          // initialize state; here we randomly perturb a constant state
          GridFunction w(fes.get());
-         VectorFunctionCoefficient pert(num_state, randBaselinePert<dim, entvar>);
+         VectorFunctionCoefficient pert(num_state, randBaselineVectorPert<dim, entvar>);
          w.ProjectCoefficient(pert);
 
          // initialize the vector that the Jacobian multiplies
          GridFunction v(fes.get());
-         VectorFunctionCoefficient v_rand(num_state, randState);
+         VectorFunctionCoefficient v_rand(num_state, randVectorState);
          v.ProjectCoefficient(v_rand);
 
          // evaluate the Jacobian and compute its product with v

--- a/test/unit/test_euler_sens_integ.cpp
+++ b/test/unit/test_euler_sens_integ.cpp
@@ -41,7 +41,7 @@ TEMPLATE_TEST_CASE_SIG("IsmailRoeMeshSensIntegrator::AssembleElementVector",
 
          // initialize state and adjoint; here we randomly perturb a constant state
          GridFunction state(fes.get()), adjoint(fes.get());
-         VectorFunctionCoefficient pert(num_state, randBaselinePert<2,entvar>);
+         VectorFunctionCoefficient pert(num_state, randBaselineVectorPert<2,entvar>);
          state.ProjectCoefficient(pert);
          adjoint.ProjectCoefficient(pert);
 
@@ -58,7 +58,7 @@ TEMPLATE_TEST_CASE_SIG("IsmailRoeMeshSensIntegrator::AssembleElementVector",
 
          // initialize the vector that we use to perturb the mesh nodes
          GridFunction v(mesh_fes);
-         VectorFunctionCoefficient v_rand(dim, randState);
+         VectorFunctionCoefficient v_rand(dim, randVectorState);
          v.ProjectCoefficient(v_rand);
 
          // contract dfdx with v
@@ -117,7 +117,7 @@ TEMPLATE_TEST_CASE_SIG("SlipWallBCMeshSens::AssembleRHSElementVect",
 
          // initialize state and adjoint; here we randomly perturb a constant state
          GridFunction state(fes.get()), adjoint(fes.get());
-         VectorFunctionCoefficient pert(num_state, randBaselinePert<2,entvar>);
+         VectorFunctionCoefficient pert(num_state, randBaselineVectorPert<2,entvar>);
          state.ProjectCoefficient(pert);
          adjoint.ProjectCoefficient(pert);
 
@@ -134,7 +134,7 @@ TEMPLATE_TEST_CASE_SIG("SlipWallBCMeshSens::AssembleRHSElementVect",
 
          // initialize the vector that we use to perturb the mesh nodes
          GridFunction v(mesh_fes);
-         VectorFunctionCoefficient v_rand(dim, randState);
+         VectorFunctionCoefficient v_rand(dim, randVectorState);
          v.ProjectCoefficient(v_rand);
 
          // contract dfdx with v

--- a/test/unit/test_navier_stokes_assemble.cpp
+++ b/test/unit/test_navier_stokes_assemble.cpp
@@ -38,12 +38,12 @@ TEST_CASE("ESViscousIntegrator::AssembleElementGrad", "[ESViscousIntegrator]")
 
          // initialize state; here we randomly perturb a constant state
          GridFunction q(fes.get());
-         VectorFunctionCoefficient pert(num_state, randBaselinePert<2>);
+         VectorFunctionCoefficient pert(num_state, randBaselineVectorPert<2>);
          q.ProjectCoefficient(pert);
 
          // initialize the vector that the Jacobian multiplies
          GridFunction v(fes.get());
-         VectorFunctionCoefficient v_rand(num_state, randState);
+         VectorFunctionCoefficient v_rand(num_state, randVectorState);
          v.ProjectCoefficient(v_rand);
 
          // evaluate the Jacobian and compute its product with v
@@ -109,12 +109,12 @@ TEST_CASE("NoSlipAdiabaticWallBC::AssembleFaceGrad", "[NoSlipBC]")
 
          // initialize state; here we randomly perturb a constant state
          GridFunction q(fes.get());
-         VectorFunctionCoefficient pert(num_state, randBaselinePert<dim>);
+         VectorFunctionCoefficient pert(num_state, randBaselineVectorPert<dim>);
          q.ProjectCoefficient(pert);
 
          // initialize the vector that the Jacobian multiplies
          GridFunction v(fes.get());
-         VectorFunctionCoefficient v_rand(num_state, randState);
+         VectorFunctionCoefficient v_rand(num_state, randVectorState);
          v.ProjectCoefficient(v_rand);
 
          // evaluate the Jacobian and compute its product with v
@@ -172,12 +172,12 @@ TEST_CASE("ViscousSlipWallBC::AssembleFaceGrad", "[VisSlipWallBC]")
 
          // initialize state; here we randomly perturb a constant state
          GridFunction q(fes.get());
-         VectorFunctionCoefficient pert(num_state, randBaselinePert<dim>);
+         VectorFunctionCoefficient pert(num_state, randBaselineVectorPert<dim>);
          q.ProjectCoefficient(pert);
 
          // initialize the vector that the Jacobian multiplies
          GridFunction v(fes.get());
-         VectorFunctionCoefficient v_rand(num_state, randState);
+         VectorFunctionCoefficient v_rand(num_state, randVectorState);
          v.ProjectCoefficient(v_rand);
 
          // evaluate the Jacobian and compute its product with v
@@ -243,12 +243,12 @@ TEST_CASE("ViscousInflowWallBC::AssembleFaceGrad", "[VisInflowBC]")
 
          // initialize state; here we randomly perturb a constant state
          GridFunction q(fes.get());
-         VectorFunctionCoefficient pert(num_state, randBaselinePert<dim>);
+         VectorFunctionCoefficient pert(num_state, randBaselineVectorPert<dim>);
          q.ProjectCoefficient(pert);
 
          // initialize the vector that the Jacobian multiplies
          GridFunction v(fes.get());
-         VectorFunctionCoefficient v_rand(num_state, randState);
+         VectorFunctionCoefficient v_rand(num_state, randVectorState);
          v.ProjectCoefficient(v_rand);
 
          // evaluate the Jacobian and compute its product with v
@@ -314,12 +314,12 @@ TEST_CASE("ViscousOutflowBC::AssembleFaceGrad", "[VisOutflowBC]")
 
          // initialize state; here we randomly perturb a constant state
          GridFunction q(fes.get());
-         VectorFunctionCoefficient pert(num_state, randBaselinePert<dim>);
+         VectorFunctionCoefficient pert(num_state, randBaselineVectorPert<dim>);
          q.ProjectCoefficient(pert);
 
          // initialize the vector that the Jacobian multiplies
          GridFunction v(fes.get());
-         VectorFunctionCoefficient v_rand(num_state, randState);
+         VectorFunctionCoefficient v_rand(num_state, randVectorState);
          v.ProjectCoefficient(v_rand);
 
          // evaluate the Jacobian and compute its product with v
@@ -385,12 +385,12 @@ TEST_CASE("ViscousFarFieldBC::AssembleFaceGrad", "[VisFarFieldBC]")
 
          // initialize state; here we randomly perturb a constant state
          GridFunction q(fes.get());
-         VectorFunctionCoefficient pert(num_state, randBaselinePert<dim>);
+         VectorFunctionCoefficient pert(num_state, randBaselineVectorPert<dim>);
          q.ProjectCoefficient(pert);
 
          // initialize the vector that the Jacobian multiplies
          GridFunction v(fes.get());
-         VectorFunctionCoefficient v_rand(num_state, randState);
+         VectorFunctionCoefficient v_rand(num_state, randVectorState);
          v.ProjectCoefficient(v_rand);
 
          // evaluate the Jacobian and compute its product with v
@@ -460,12 +460,12 @@ TEST_CASE("SurfaceForce::AssembleVector", "[Surface Force]")
 
          // initialize state; here we randomly perturb a constant state
          GridFunction q(fes.get());
-         VectorFunctionCoefficient pert(num_state, randBaselinePert<dim>);
+         VectorFunctionCoefficient pert(num_state, randBaselineVectorPert<dim>);
          q.ProjectCoefficient(pert);
 
          // initialize the vector that dJdu multiplies
          GridFunction v(fes.get());
-         VectorFunctionCoefficient v_rand(num_state, randState);
+         VectorFunctionCoefficient v_rand(num_state, randVectorState);
          v.ProjectCoefficient(v_rand);
 
          // evaluate dJdu and compute its product with v
@@ -497,12 +497,12 @@ TEST_CASE("SurfaceForce::AssembleVector", "[Surface Force]")
 
          // initialize state; here we randomly perturb a constant state
          GridFunction q(fes.get());
-         VectorFunctionCoefficient pert(num_state, randBaselinePert<dim>);
+         VectorFunctionCoefficient pert(num_state, randBaselineVectorPert<dim>);
          q.ProjectCoefficient(pert);
 
          // initialize the vector that dJdu multiplies
          GridFunction v(fes.get());
-         VectorFunctionCoefficient v_rand(num_state, randState);
+         VectorFunctionCoefficient v_rand(num_state, randVectorState);
          v.ProjectCoefficient(v_rand);
 
          // evaluate dJdu and compute its product with v

--- a/test/unit/test_res_integ.cpp
+++ b/test/unit/test_res_integ.cpp
@@ -53,7 +53,7 @@ TEST_CASE("DomainResIntegrator::AssembleElementVector",
 
          // initialize the vector that we use to perturb the mesh nodes
          GridFunction v(mesh_fes);
-         VectorFunctionCoefficient v_rand(dim, randState);
+         VectorFunctionCoefficient v_rand(dim, randVectorState);
          v.ProjectCoefficient(v_rand);
 
          // evaluate df/dx and contract with v
@@ -128,7 +128,7 @@ TEST_CASE("MassResIntegrator::AssembleElementVector",
 
          // initialize the vector that we use to perturb the mesh nodes
          GridFunction v(mesh_fes);
-         VectorFunctionCoefficient v_rand(dim, randState);
+         VectorFunctionCoefficient v_rand(dim, randVectorState);
          v.ProjectCoefficient(v_rand);
 
          // evaluate df/dx and contract with v
@@ -207,7 +207,7 @@ TEST_CASE("DiffusionResIntegrator::AssembleElementVector",
 
          // initialize the vector that we use to perturb the mesh nodes
          GridFunction v(mesh_fes);
-         VectorFunctionCoefficient v_rand(dim, randState);
+         VectorFunctionCoefficient v_rand(dim, randVectorState);
          v.ProjectCoefficient(v_rand);
 
          // evaluate df/dx and contract with v
@@ -288,7 +288,7 @@ TEST_CASE("BoundaryNormalResIntegrator::AssembleFaceVector",
 
          // initialize the vector that we use to perturb the mesh nodes
          GridFunction v(mesh_fes);
-         VectorFunctionCoefficient v_rand(dim, randState);
+         VectorFunctionCoefficient v_rand(dim, randVectorState);
          v.ProjectCoefficient(v_rand);
 
          // evaluate df/dx and contract with v

--- a/test/unit/test_thermal_integ.cpp
+++ b/test/unit/test_thermal_integ.cpp
@@ -181,7 +181,7 @@ TEST_CASE("AggregateResIntegrator::AssembleVector", "[AggregateResIntegrator]")
          
          // initialize the vector that dJdx multiplies
          GridFunction v(mesh_fes);
-         VectorFunctionCoefficient v_rand(dim, randState);
+         VectorFunctionCoefficient v_rand(dim, randVectorState);
          v.ProjectCoefficient(v_rand);
 
          // evaluate dJdx and compute its product with v


### PR DESCRIPTION
My mfem PR that switched function coefficients to use `std::functions` was merged into mfem's master branch, and removed support for defining function coefficients with overloaded functions. I've updated the unit tests so that our code is now compatible.