### PR TITLE
Update SBP FECs to new FEC constructor

### DIFF
--- a/src/common/sbp_fe.cpp
+++ b/src/common/sbp_fe.cpp
@@ -868,6 +868,7 @@ void SBPTriangleElement::CalcDShape(const IntegrationPoint &ip,
 }
 
 SBPCollection::SBPCollection(const int p, const int dim)
+   : FiniteElementCollection(p)
 {
    MFEM_VERIFY(p >= 0 && p <= 4, "SBPCollection requires 0 <= order <= 4.");
    MFEM_VERIFY(dim == 2, "SBPCollection requires dim == 2.");
@@ -1023,6 +1024,7 @@ SBPCollection::~SBPCollection()
 
 // From here thee DSBPCollection class 
 DSBPCollection::DSBPCollection(const int p, const int dim)
+   : FiniteElementCollection(p)
 {
    MFEM_VERIFY(p >= 0 && p <= 4, "SBPCollection requires 0 <= order <= 4.");
    MFEM_VERIFY(dim == 2, "SBPCollection requires dim == 2.");


### PR DESCRIPTION
I had to merge mfem's `master` into `odl` today, which caused tests to fail because the `FiniteElementCollection` constructor changed. This PR fixes the constructors for `SBPCollection` and `DSBPCollection` so that they're compatible with the latest from mfem.