### PR TITLE
Fix solver method `calcResidualNorm` with no state inputs

### DIFF
--- a/sandbox/airfoil_chaotic_options.json
+++ b/sandbox/airfoil_chaotic_options.json
@@ -9,7 +9,8 @@
       "pitch-axis": 1,
       "Re": 3500.0,
       "Pr": 0.72,
-      "mu": -1.0
+      "mu": -1.0,
+      "viscous-mms": false
    },
    "space-dis": {
       "degree": 2,

--- a/src/physics/solver.cpp
+++ b/src/physics/solver.cpp
@@ -782,7 +782,14 @@ double AbstractSolver::calcL2Error(
    *scratch = field;
    return calcL2Error(scratch.get(), u_exact, entry);
 }
+double AbstractSolver::calcResidualNorm() const
+{
+   HypreParVector u_true(fes.get());
+   u->GetTrueVector().SetDataAndSize(u_true.GetData(), u_true.Size());
+   u->SetTrueVector();
 
+   return calcResidualNorm(*u);
+}
 double AbstractSolver::calcResidualNorm(const ParGridFunction &state) const
 {
    MachInputs inputs {

--- a/src/physics/solver.hpp
+++ b/src/physics/solver.hpp
@@ -471,7 +471,7 @@ public:
    
    /// Compute the residual norm based on the current solution in `u`
    /// \returns the l2 (discrete) norm of the residual evaluated at `u`
-   double calcResidualNorm() const { return calcResidualNorm(*u); };
+   double calcResidualNorm() const;
 
    /// Compute the residual norm based on the input `state`
    /// \returns the l2 (discrete) norm of the residual evaluated at `u`


### PR DESCRIPTION
This fixes the call to `calcResidualNorm` with no inputs, but then I still get an error when running `airfoil_chaotic.bin` that `ESViscousIntegrator::GetElementEnergy` is not overloaded...